### PR TITLE
Using groups for dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,13 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    groups:
+      "otel":
+        patterns:
+          - "go.opentelemetry.io/*"
+      "fortio":
+        patterns:
+          - "fortio.org/*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
- otel in 1 group
- fortio in another

assuming 'rest' would be handled too